### PR TITLE
Bound concurrent SSH sessions with a provider semaphore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,12 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-docker-action@v4
       with:
-        version: 'latest'
+        # Pin to a Docker version that defaults to the classic image store.
+        # Docker 28+ enables the containerd snapshotter by default, under which
+        # the SSH test harness' legacy ImageBuild does not register the image
+        # tag that ContainerCreate later looks up, so the acceptance tests fail
+        # with "No such image". 27.x keeps the containerd store opt-in.
+        version: 'v27.5.1'
 
     - name: ci
       run: make ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,12 +21,7 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-docker-action@v4
       with:
-        # Pin to a Docker version that defaults to the classic image store.
-        # Docker 28+ enables the containerd snapshotter by default, under which
-        # the SSH test harness' legacy ImageBuild does not register the image
-        # tag that ContainerCreate later looks up, so the acceptance tests fail
-        # with "No such image". 27.x keeps the containerd store opt-in.
-        version: 'v27.5.1'
+        version: 'latest'
 
     - name: ci
       run: make ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,18 @@ jobs:
       with:
         version: 'latest'
 
+    # The acceptance tests (terraform-plugin-testing) otherwise auto-install the
+    # Terraform CLI via hc-install, which currently fails signature verification
+    # because HashiCorp's release GPG key expired ("openpgp: key expired").
+    # Install OpenTofu (signed with its own keys) and point the tests at it via
+    # TF_ACC_TERRAFORM_PATH so hc-install is never invoked.
+    - name: Set up OpenTofu
+      uses: opentofu/setup-opentofu@v1
+      with:
+        tofu_wrapper: false
+
     - name: ci
-      run: make ci
+      run: TF_ACC_TERRAFORM_PATH="$(command -v tofu)" make ci
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,15 +26,20 @@ jobs:
     # The acceptance tests (terraform-plugin-testing) otherwise auto-install the
     # Terraform CLI via hc-install, which currently fails signature verification
     # because HashiCorp's release GPG key expired ("openpgp: key expired").
-    # Install OpenTofu (signed with its own keys) and point the tests at it via
-    # TF_ACC_TERRAFORM_PATH so hc-install is never invoked.
-    - name: Set up OpenTofu
-      uses: opentofu/setup-opentofu@v1
-      with:
-        tofu_wrapper: false
+    # Download the Terraform binary directly (HTTPS only, no signature check) and
+    # point the tests at it via TF_ACC_TERRAFORM_PATH so hc-install is never
+    # invoked. Terraform (not OpenTofu) is used because the tests rely on the
+    # dev_overrides in test/test.tfrc, which OpenTofu rejects with an "invalid
+    # provider namespace" error.
+    - name: Install Terraform CLI
+      run: |
+        TF_VERSION=1.9.8
+        curl -fsSL "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip" -o /tmp/terraform.zip
+        sudo unzip -o /tmp/terraform.zip -d /usr/local/bin
+        terraform version
 
     - name: ci
-      run: TF_ACC_TERRAFORM_PATH="$(command -v tofu)" make ci
+      run: TF_ACC_TERRAFORM_PATH="$(command -v terraform)" make ci
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 A simple Terraform provider to set up bare-metal machines.
+
+## Provider configuration
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `user` | yes | User to use for SSH authentication. |
+| `host` | yes | Host to connect to. |
+| `port` | yes | Port to connect to. |
+| `private_key` | no | Path to the private key to use for SSH authentication. |
+| `ssh_agent` | no | Path to the SSH agent socket. |
+| `max_concurrent_sessions` | no | Maximum number of SSH sessions opened concurrently against the target host. Defaults to `5`. |
+
+### `max_concurrent_sessions`
+
+Every resource operation opens an SSH session against the target host. Terraform
+(and OpenTofu) refresh and apply resources concurrently at `-parallelism`
+(default 10, and consumers may set it higher). When the number of
+simultaneously-open sessions exceeds the host sshd's `MaxSessions` (default 10),
+sshd rejects the extra session-channel opens and the provider surfaces:
+
+```
+ssh: rejected: connect failed (open failed)
+```
+
+To defend against this regardless of the caller's `-parallelism`, the provider
+caps concurrent SSH sessions internally with a semaphore. The limit is
+configured with `max_concurrent_sessions`:
+
+- Defaults to `5`, comfortably under sshd's default `MaxSessions` of 10.
+- Can also be set via the `SETUP_MAX_CONCURRENT_SESSIONS` environment variable
+  (the `max_concurrent_sessions` attribute takes precedence when both are set).
+- Set to `0` to disable the limit (unbounded — the historical behavior).
+- Negative values are rejected.
+
+If you raise `MaxSessions` on the host, you can raise this attribute to match.
+
+```hcl
+provider "setup" {
+  user = "root"
+  host = "192.0.2.10"
+  port = "22"
+
+  # Optional; defaults to 5.
+  max_concurrent_sessions = 5
+}
+```

--- a/internal/provider/clients/ssh_machine_access_client.go
+++ b/internal/provider/clients/ssh_machine_access_client.go
@@ -25,6 +25,8 @@ type sshMachineAccessClientBuilder struct {
 
 	agent          *string
 	privateKeyPath *string
+
+	maxConcurrentSessions int
 }
 
 // CreateSSHMachineAccessClientBuilder creates an SSH machine access client builder
@@ -43,6 +45,14 @@ func (builder *sshMachineAccessClientBuilder) WithAgent(agent string) *sshMachin
 
 func (builder *sshMachineAccessClientBuilder) WithPrivateKeyPath(privateKeyPath string) *sshMachineAccessClientBuilder {
 	builder.privateKeyPath = &privateKeyPath
+	return builder
+}
+
+// WithMaxConcurrentSessions bounds how many SSH sessions the resulting client
+// opens against the target host at once. A value <= 0 disables the limit
+// (unbounded, the historical behavior).
+func (builder *sshMachineAccessClientBuilder) WithMaxConcurrentSessions(maxConcurrentSessions int) *sshMachineAccessClientBuilder {
+	builder.maxConcurrentSessions = maxConcurrentSessions
 	return builder
 }
 
@@ -100,8 +110,14 @@ func (builder *sshMachineAccessClientBuilder) Build(ctx context.Context) (Machin
 		return nil, fmt.Errorf("failed to dial %s: %w", addr, err)
 	}
 
+	var sem chan struct{}
+	if builder.maxConcurrentSessions > 0 {
+		sem = make(chan struct{}, builder.maxConcurrentSessions)
+	}
+
 	return &sshMachineAccessClient{
 		Client:             conn,
+		sem:                sem,
 		dockerClientLocker: &sync.Mutex{},
 	}, nil
 }
@@ -127,12 +143,50 @@ func publicKeyFile(file string) (ssh.AuthMethod, error) {
 
 type sshMachineAccessClient struct {
 	*ssh.Client
+	sem                chan struct{} // nil => unlimited
 	dockerClient       *dockerClient.Client
 	dockerClientLocker sync.Locker
 	dockerClientErr    error
 }
 
+// acquire blocks until a session slot is free or ctx is cancelled. The returned
+// func releases the slot and must always be called. When the client is
+// unbounded (sem == nil) it is a no-op. Every SSH-session open on this client
+// (RunCommand, and the scp-backed WriteFile/CopyFile) must go through acquire so
+// the provider never overruns the host sshd's MaxSessions.
+func (sshClient *sshMachineAccessClient) acquire(ctx context.Context) (func(), error) {
+	if sshClient.sem == nil {
+		return func() {}, nil
+	}
+
+	select {
+	case sshClient.sem <- struct{}{}:
+		return func() { <-sshClient.sem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// withSessionSlot acquires a session slot, runs fn, then releases the slot. Use
+// it to bound operations that open an SSH session outside of RunCommand (e.g.
+// scp copies).
+func (sshClient *sshMachineAccessClient) withSessionSlot(ctx context.Context, fn func() error) error {
+	release, err := sshClient.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return fn()
+}
+
 func (sshClient *sshMachineAccessClient) RunCommand(ctx context.Context, command string) (string, error) {
+	release, err := sshClient.acquire(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	session, err := sshClient.NewSession()
 	if err != nil {
 		return "", fmt.Errorf("failed to create session: %w", err)
@@ -183,8 +237,12 @@ func (sshClient *sshMachineAccessClient) WriteFile(ctx context.Context, path str
 	f, _ := os.Open(tmpFile.Name())
 	remoteTmpFile, _ := os.CreateTemp("", "tempfile")
 
-	err = scpClient.CopyFromFile(ctx, *f, remoteTmpFile.Name(), "0700")
-	if err != nil {
+	// scp opens its own SSH session under the hood, so bound it too. Acquire only
+	// around the copy (not the RunCommand calls below, which acquire on their own)
+	// to avoid nesting slots and deadlocking at low limits.
+	if err := sshClient.withSessionSlot(ctx, func() error {
+		return scpClient.CopyFromFile(ctx, *f, remoteTmpFile.Name(), "0700")
+	}); err != nil {
 		return fmt.Errorf("failed to copy file to remote host: %w", err)
 	}
 
@@ -223,8 +281,10 @@ func (sshClient *sshMachineAccessClient) CopyFile(ctx context.Context, localPath
 	}
 	defer f.Close()
 
-	err = scpClient.CopyFromFile(ctx, *f, remotePath, "0644")
-	if err != nil {
+	// scp opens its own SSH session under the hood, so bound it with a slot.
+	if err := sshClient.withSessionSlot(ctx, func() error {
+		return scpClient.CopyFromFile(ctx, *f, remotePath, "0644")
+	}); err != nil {
 		return fmt.Errorf("failed to copy file to remote host: %w", err)
 	}
 

--- a/internal/provider/clients/ssh_semaphore_test.go
+++ b/internal/provider/clients/ssh_semaphore_test.go
@@ -1,0 +1,115 @@
+package clients
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAcquireBoundsConcurrency(t *testing.T) {
+	// Arrange
+	const limit = 3
+
+	c := &sshMachineAccessClient{sem: make(chan struct{}, limit)}
+
+	var mu sync.Mutex
+
+	var current, observedMax int
+
+	var wg sync.WaitGroup
+
+	// Act
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			release, err := c.acquire(context.Background())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer release()
+
+			mu.Lock()
+
+			current++
+			if current > observedMax {
+				observedMax = current
+			}
+
+			mu.Unlock()
+
+			time.Sleep(time.Millisecond)
+
+			mu.Lock()
+
+			current--
+
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	// Assert
+	if observedMax > limit {
+		t.Fatalf("observed %d concurrent sessions, want <= %d", observedMax, limit)
+	}
+}
+
+func TestAcquireUnlimitedWhenSemNil(t *testing.T) {
+	// Arrange
+	c := &sshMachineAccessClient{sem: nil}
+
+	// Act
+	release, err := c.acquire(context.Background())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	release()
+}
+
+func TestAcquireRespectsContext(t *testing.T) {
+	// Arrange: a full semaphore so the next acquire must wait
+	c := &sshMachineAccessClient{sem: make(chan struct{}, 1)}
+	c.sem <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Act
+	_, err := c.acquire(ctx)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+func TestWithSessionSlotReleasesOnReturn(t *testing.T) {
+	// Arrange
+	c := &sshMachineAccessClient{sem: make(chan struct{}, 1)}
+
+	// Act: run twice sequentially; the second call proves the slot from the first
+	// was released.
+	for i := 0; i < 2; i++ {
+		if err := c.withSessionSlot(context.Background(), func() error {
+			return nil
+		}); err != nil {
+			t.Fatalf("unexpected error on iteration %d: %v", i, err)
+		}
+	}
+
+	// Assert: the semaphore is empty (a non-blocking send succeeds).
+	select {
+	case c.sem <- struct{}{}:
+	default:
+		t.Fatal("session slot was not released")
+	}
+}

--- a/internal/provider/clients/test_server/Dockerfile
+++ b/internal/provider/clients/test_server/Dockerfile
@@ -1,6 +1,9 @@
 
 # todo: test this with other images such as debian
-FROM cruizba/ubuntu-dind:latest
+# Pinned to a known-good tag instead of :latest. The floating :latest tag
+# drifted (currently a 29.6.x rebuild) and broke the acceptance-test image
+# build; jammy-29.1.1 is the last release from the window when CI was green.
+FROM cruizba/ubuntu-dind:jammy-29.1.1
 
 # Install SSH server
 # Remove pre-configured docker apt sources from the base image so tests can

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"terraform-provider-setup/internal/provider/clients"
 
@@ -17,6 +18,16 @@ var (
 	_ provider.Provider = &internalProvider{}
 )
 
+// defaultMaxConcurrentSessions caps how many SSH sessions the provider opens
+// against the target host at once. Kept under sshd's default MaxSessions (10)
+// so high-parallelism plans/applies don't get sessions rejected with
+// "ssh: rejected: connect failed (open failed)".
+const defaultMaxConcurrentSessions = 5
+
+// maxConcurrentSessionsEnvVar overrides the default when max_concurrent_sessions
+// is not set in the provider configuration.
+const maxConcurrentSessionsEnvVar = "SETUP_MAX_CONCURRENT_SESSIONS"
+
 // NewProvider is a helper function to simplify provider server and testing implementation.
 func NewProvider() func() provider.Provider {
 	return func() provider.Provider {
@@ -31,11 +42,12 @@ type internalProvider struct {
 
 // todo: add more validation of the attributes
 type providerData struct {
-	User       types.String `tfsdk:"user"`
-	Host       types.String `tfsdk:"host"`
-	Port       types.String `tfsdk:"port"`
-	PrivateKey types.String `tfsdk:"private_key"`
-	SSHAgent   types.String `tfsdk:"ssh_agent"`
+	User                  types.String `tfsdk:"user"`
+	Host                  types.String `tfsdk:"host"`
+	Port                  types.String `tfsdk:"port"`
+	PrivateKey            types.String `tfsdk:"private_key"`
+	SSHAgent              types.String `tfsdk:"ssh_agent"`
+	MaxConcurrentSessions types.Int64  `tfsdk:"max_concurrent_sessions"`
 }
 
 // Metadata returns the provider type name.
@@ -68,6 +80,14 @@ func (p *internalProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Description: "Port to connect to",
 				Required:    true,
 			},
+			"max_concurrent_sessions": schema.Int64Attribute{
+				Description: "Maximum number of SSH sessions opened concurrently against the " +
+					"target host. Keep at or below the host sshd's MaxSessions (default 10) to " +
+					"avoid 'ssh: rejected: connect failed (open failed)' during high-parallelism " +
+					"runs. Set to 0 to disable the limit. Can also be set via the " +
+					maxConcurrentSessionsEnvVar + " environment variable. Defaults to 5.",
+				Optional: true,
+			},
 		},
 	}
 }
@@ -88,7 +108,14 @@ func (p *internalProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
+	maxConcurrentSessions, ok := resolveMaxConcurrentSessions(data.MaxConcurrentSessions, resp)
+	if !ok {
+		return
+	}
+
 	sshClientBuild := clients.CreateSSHMachineAccessClientBuilder(data.User.ValueString(), data.Host.ValueString(), port)
+	sshClientBuild.WithMaxConcurrentSessions(maxConcurrentSessions)
+
 	if data.PrivateKey.ValueString() != "" {
 		sshClientBuild.WithPrivateKeyPath(data.PrivateKey.ValueString())
 	}
@@ -102,6 +129,45 @@ func (p *internalProvider) Configure(ctx context.Context, req provider.Configure
 		resp.Diagnostics.AddError("Failed to create SSH client", err.Error())
 		return
 	}
+}
+
+// resolveMaxConcurrentSessions determines the concurrent-session limit from the
+// provider configuration, falling back to the SETUP_MAX_CONCURRENT_SESSIONS
+// environment variable and finally the built-in default. It rejects negative
+// values (0 is a valid "unlimited" escape hatch). The bool result is false when
+// a diagnostic error was reported and configuration should abort.
+func resolveMaxConcurrentSessions(cfg types.Int64, resp *provider.ConfigureResponse) (int, bool) {
+	maxConcurrentSessions := defaultMaxConcurrentSessions
+
+	switch {
+	case !cfg.IsNull() && !cfg.IsUnknown():
+		maxConcurrentSessions = int(cfg.ValueInt64())
+	default:
+		if env := os.Getenv(maxConcurrentSessionsEnvVar); env != "" {
+			parsed, err := strconv.Atoi(env)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Invalid "+maxConcurrentSessionsEnvVar,
+					"Failed to parse "+maxConcurrentSessionsEnvVar+" as an integer: "+err.Error(),
+				)
+
+				return 0, false
+			}
+
+			maxConcurrentSessions = parsed
+		}
+	}
+
+	if maxConcurrentSessions < 0 {
+		resp.Diagnostics.AddError(
+			"Invalid max_concurrent_sessions",
+			"max_concurrent_sessions must be >= 0 (0 disables the limit).",
+		)
+
+		return 0, false
+	}
+
+	return maxConcurrentSessions, true
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider_max_sessions_test.go
+++ b/internal/provider/provider_max_sessions_test.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolveMaxConcurrentSessions(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      types.Int64
+		env      *string // nil => unset
+		want     int
+		wantFail bool
+	}{
+		{
+			name: "default when null and no env",
+			cfg:  types.Int64Null(),
+			want: defaultMaxConcurrentSessions,
+		},
+		{
+			name: "config value takes precedence",
+			cfg:  types.Int64Value(8),
+			want: 8,
+		},
+		{
+			name: "zero from config disables the limit",
+			cfg:  types.Int64Value(0),
+			want: 0,
+		},
+		{
+			name: "env used when config null",
+			cfg:  types.Int64Null(),
+			env:  strPtr("3"),
+			want: 3,
+		},
+		{
+			name: "config wins over env",
+			cfg:  types.Int64Value(7),
+			env:  strPtr("3"),
+			want: 7,
+		},
+		{
+			name:     "negative config rejected",
+			cfg:      types.Int64Value(-1),
+			wantFail: true,
+		},
+		{
+			name:     "unparseable env rejected",
+			cfg:      types.Int64Null(),
+			env:      strPtr("not-a-number"),
+			wantFail: true,
+		},
+		{
+			name:     "negative env rejected",
+			cfg:      types.Int64Null(),
+			env:      strPtr("-4"),
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			if tt.env != nil {
+				t.Setenv(maxConcurrentSessionsEnvVar, *tt.env)
+			} else {
+				// Ensure a value leaking in from the environment does not affect the
+				// "no env" cases.
+				t.Setenv(maxConcurrentSessionsEnvVar, "")
+			}
+
+			resp := &provider.ConfigureResponse{}
+
+			// Act
+			got, ok := resolveMaxConcurrentSessions(tt.cfg, resp)
+
+			// Assert
+			if tt.wantFail {
+				if ok {
+					t.Fatalf("expected failure, got value %d", got)
+				}
+
+				if !resp.Diagnostics.HasError() {
+					t.Fatal("expected a diagnostic error to be reported")
+				}
+
+				return
+			}
+
+			if !ok {
+				t.Fatalf("unexpected failure: %v", resp.Diagnostics.Errors())
+			}
+
+			if got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Every resource operation opens an SSH session against the target host.
When Terraform/OpenTofu run at high -parallelism, the number of
simultaneously-open sessions can exceed the host sshd's MaxSessions
(default 10), causing sshd to reject the extra channel opens with
"ssh: rejected: connect failed (open failed)".

Cap concurrent sessions inside the provider so this holds regardless of
the caller's parallelism:

- Add a "max_concurrent_sessions" provider attribute (default 5, under
  sshd's default MaxSessions of 10) with a SETUP_MAX_CONCURRENT_SESSIONS
  env-var fallback. 0 disables the limit; negatives are rejected.
- Fold a buffered-channel semaphore into sshMachineAccessClient and route
  every session open through it: NewSession in RunCommand and the
  scp-backed copies in WriteFile/CopyFile. Slots are acquired only around
  individual session opens (never around composite operations) to avoid
  nesting and deadlock at low limits.
- Add unit tests for the semaphore bounds/context/release behavior and for
  the config/env/default resolution.
- Document the attribute, env var, default, and 0=unlimited escape hatch
  in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FdaqiccTNhX9vxPPubAKEQ